### PR TITLE
Update emu-t and emu-nt for line breaks.

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -164,6 +164,7 @@ emu-rhs emu-nt {
 emu-t {
     font-family: monospace;
     font-weight: bold;
+    white-space: nowrap;
 }
 
 emu-production emu-t {

--- a/lib/NonTerminal.js
+++ b/lib/NonTerminal.js
@@ -29,9 +29,23 @@ module.exports = class NonTerminal extends Builder {
       modifiers += '<emu-opt>opt</emu-opt>';
     }
 
-    const el = this.spec.doc.createElement('emu-mods');
-    el.innerHTML = modifiers;
+    if (modifiers !== '') {
+      const el = this.spec.doc.createElement('emu-mods');
+      el.innerHTML = modifiers;
 
-    this.node.appendChild(el);
+      this.node.appendChild(el);
+    }
+
+    // To break line if it's overflowed.
+
+    const nextSibling = this.node.nextSibling;
+    // Chrome does not make new line at \u200B.
+    this.node.parentNode.insertBefore(
+      this.spec.doc.createElement('wbr'),
+      nextSibling);
+    // IE does not make new line at <wbr>.
+    this.node.parentNode.insertBefore(
+      this.spec.doc.createTextNode('\u200B'),
+      nextSibling);
   }
 };

--- a/lib/Terminal.js
+++ b/lib/Terminal.js
@@ -16,10 +16,22 @@ Terminal.prototype.build = function () {
     modifiers += '<emu-opt>opt</emu-opt>';
   }
 
-  if (modifiers === '') return null;
+  if (modifiers !== '') {
+    const el = this.spec.doc.createElement('emu-mods');
+    el.innerHTML = modifiers;
 
-  const el = this.spec.doc.createElement('emu-mods');
-  el.innerHTML = modifiers;
+    this.node.appendChild(el);
+  }
 
-  this.node.appendChild(el);
+  // To break line if it's overflowed.
+
+  const nextSibling = this.node.nextSibling;
+  // Chrome does not make new line at \u200B.
+  this.node.parentNode.insertBefore(
+    this.spec.doc.createElement('wbr'),
+    nextSibling);
+  // IE does not make new line at <wbr>.
+  this.node.parentNode.insertBefore(
+    this.spec.doc.createTextNode('\u200B'),
+    nextSibling);
 };

--- a/test/test.html.baseline
+++ b/test/test.html.baseline
@@ -41,61 +41,61 @@
   <emu-note><span class="note">Note</span>Note!</emu-note>
 
   <emu-production name="WhileStatement" id="prod-WhileStatement">
-    <emu-nt><a href="#prod-WhileStatement">WhileStatement</a><emu-mods></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-t>while</emu-t><emu-t>(</emu-t><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-Expression">Expression</a><emu-mods></emu-mods></emu-nt><emu-t>)</emu-t><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-Statement">Statement</a><emu-mods></emu-mods></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-WhileStatement">WhileStatement</a></emu-nt><wbr>​<emu-geq>:</emu-geq><emu-rhs><emu-t>while</emu-t><wbr>​<emu-t>(</emu-t><wbr>​<emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-Expression">Expression</a></emu-nt><wbr>​<emu-t>)</emu-t><wbr>​<emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-Statement">Statement</a></emu-nt><wbr>​</emu-rhs>
   </emu-production>
 
   <emu-production name="ArgumentList" id="prod-ArgumentList">
-    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a><emu-mods></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs a="a"><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-AssignmentExpression">AssignmentExpression</a><emu-mods></emu-mods></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><wbr>​<emu-geq>:</emu-geq><emu-rhs a="a"><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-AssignmentExpression">AssignmentExpression</a></emu-nt><wbr>​</emu-rhs>
 
-    <emu-rhs a="b"><emu-nt><a href="#prod-ArgumentList">ArgumentList</a><emu-mods></emu-mods></emu-nt><emu-t>,</emu-t><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-AssignmentExpression">AssignmentExpression</a><emu-mods></emu-mods></emu-nt></emu-rhs>
+    <emu-rhs a="b"><emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><wbr>​<emu-t>,</emu-t><wbr>​<emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-AssignmentExpression">AssignmentExpression</a></emu-nt><wbr>​</emu-rhs>
   </emu-production>
 
   <emu-production name="SourceCharacter" type="lexical" id="prod-SourceCharacter">
-    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a><emu-mods></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-gprose>any Unicode code point</emu-gprose></emu-rhs>
+    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt><wbr>​<emu-geq>::</emu-geq><emu-rhs><emu-gprose>any Unicode code point</emu-gprose></emu-rhs>
   </emu-production>
 
   <emu-production name="ExpressionStatement" params="Yield" id="prod-ExpressionStatement">
-    <emu-nt params="Yield"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield]</emu-params></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-gann>[lookahead ∉ {
-        <emu-t>{</emu-t>,
-        <emu-t>function</emu-t>,
-        <emu-t>class</emu-t>,
-        <emu-t>let [</emu-t>
+    <emu-nt params="Yield"><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods><emu-params>[Yield]</emu-params></emu-mods></emu-nt><wbr>​<emu-geq>:</emu-geq><emu-rhs><emu-gann>[lookahead ∉ {
+        <emu-t>{</emu-t><wbr>​,
+        <emu-t>function</emu-t><wbr>​,
+        <emu-t>class</emu-t><wbr>​,
+        <emu-t>let [</emu-t><wbr>​
       }]</emu-gann></emu-rhs>
   </emu-production>
 
   <emu-production name="StatementList" params="Return, In" id="prod-StatementList">
-    <emu-nt params="Return, In"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-params>[Return, In]</emu-params></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs constraints="~Return"><emu-constraints>[~Return]</emu-constraints><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-ReturnStatement">ReturnStatement</a><emu-mods></emu-mods></emu-nt></emu-rhs>
-    <emu-rhs><emu-nt><a href="#prod-ExpressionStatement">ExpressionStatement</a><emu-mods></emu-mods></emu-nt></emu-rhs>
+    <emu-nt params="Return, In"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-params>[Return, In]</emu-params></emu-mods></emu-nt><wbr>​<emu-geq>:</emu-geq><emu-rhs constraints="~Return"><emu-constraints>[~Return]</emu-constraints><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-ReturnStatement">ReturnStatement</a></emu-nt><wbr>​</emu-rhs>
+    <emu-rhs><emu-nt><a href="#prod-ExpressionStatement">ExpressionStatement</a></emu-nt><wbr>​</emu-rhs>
   </emu-production>
 
   <emu-production name="Identifier" type="lexical" id="prod-Identifier">
-    <emu-nt><a href="#prod-Identifier">Identifier</a><emu-mods></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-IdentifierName">IdentifierName</a><emu-mods></emu-mods></emu-nt><emu-gmod>but not
-    <emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-ReservedWord">ReservedWord</a><emu-mods></emu-mods></emu-nt></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><wbr>​<emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-IdentifierName">IdentifierName</a></emu-nt><wbr>​<emu-gmod>but not
+    <emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-ReservedWord">ReservedWord</a></emu-nt><wbr>​</emu-gmod></emu-rhs>
   </emu-production>
 
   <emu-production name="EnumDeclaration" id="prod-EnumDeclaration">
-    <emu-nt><a href="#prod-EnumDeclaration">EnumDeclaration</a><emu-mods></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs><emu-t optional="">const<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t><emu-t>enum</emu-t><emu-nt><a href="#prod-Identifier">Identifier</a><emu-mods></emu-mods></emu-nt><emu-t>{</emu-t><emu-nt optional="">EnumBody<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><emu-t>}</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-EnumDeclaration">EnumDeclaration</a></emu-nt><wbr>​<emu-geq>:</emu-geq><emu-rhs><emu-t optional="">const<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t><wbr>​<emu-t>enum</emu-t><wbr>​<emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><wbr>​<emu-t>{</emu-t><wbr>​<emu-nt optional="">EnumBody<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt><wbr>​<emu-t>}</emu-t><wbr>​</emu-rhs>
   </emu-production>
   
   <!-- added for testing that prodref references first occurance -->
   <emu-production name="Identifier" type="lexical">
-    <emu-nt><a href="#prod-Identifier">Identifier</a><emu-mods></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-t>DummyIdentifier</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><wbr>​<emu-geq>::</emu-geq><emu-rhs><emu-t>DummyIdentifier</emu-t><wbr>​</emu-rhs>
   </emu-production>
 
   <emu-production name="Identifier" type="lexical" id="prod-Identifier">
-    <emu-nt><a href="#prod-Identifier">Identifier</a><emu-mods></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-IdentifierName">IdentifierName</a><emu-mods></emu-mods></emu-nt><emu-gmod>but not
-    <emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-ReservedWord">ReservedWord</a><emu-mods></emu-mods></emu-nt></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt><wbr>​<emu-geq>::</emu-geq><emu-rhs><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-IdentifierName">IdentifierName</a></emu-nt><wbr>​<emu-gmod>but not
+    <emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-ReservedWord">ReservedWord</a></emu-nt><wbr>​</emu-gmod></emu-rhs>
   </emu-production>
   <emu-production name="ArgumentList" id="prod-ArgumentList" a="a">
-    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a><emu-mods></emu-mods></emu-nt><emu-geq>:</emu-geq><emu-rhs a="a"><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-AssignmentExpression">AssignmentExpression</a><emu-mods></emu-mods></emu-nt></emu-rhs></emu-production>
+    <emu-nt><a href="#prod-ArgumentList">ArgumentList</a></emu-nt><wbr>​<emu-geq>:</emu-geq><emu-rhs a="a"><emu-nt><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#prod-AssignmentExpression">AssignmentExpression</a></emu-nt><wbr>​</emu-rhs></emu-production>
 
   <emu-grammar><emu-production name="FooBar" params="Yeild" type="lexical" id="prod-FooBar">
-    <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs>
-    <emu-rhs a="b"><emu-t>baz</emu-t></emu-rhs>
+    <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><wbr>​<emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><wbr>​<emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt><wbr>​</emu-rhs>
+    <emu-rhs a="b"><emu-t>baz</emu-t><wbr>​</emu-rhs>
 </emu-production></emu-grammar>
 
   <emu-production name="FooBar" params="Yeild" type="lexical" id="prod-FooBar" a="a">
-    <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt></emu-rhs></emu-production>
+    <emu-nt params="Yeild"><a href="#prod-FooBar">FooBar</a><emu-mods><emu-params>[Yeild]</emu-params></emu-mods></emu-nt><wbr>​<emu-geq>::</emu-geq><emu-rhs a="a" constraints="+Default"><emu-constraints>[+Default]</emu-constraints><emu-t>foo</emu-t><wbr>​<emu-nt params="?Yield">Bar<emu-mods><emu-params>[?Yield]</emu-params></emu-mods></emu-nt><wbr>​</emu-rhs></emu-production>
 
   <pre><code class="language-javascript hljs">
     <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">test</span>(<span class="hljs-params"></span>) </span>{ };

--- a/test/xref.html.baseline
+++ b/test/xref.html.baseline
@@ -102,6 +102,6 @@
 </emu-clause>
 
 <emu-grammar><emu-production name="TestProduction" type="lexical" id="prod-TestProduction">
-    <emu-nt><a href="#prod-TestProduction">TestProduction</a><emu-mods></emu-mods></emu-nt><emu-geq>::</emu-geq><emu-rhs a="1"><emu-t>np</emu-t><emu-t>np</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-TestProduction">TestProduction</a></emu-nt><wbr>​<emu-geq>::</emu-geq><emu-rhs a="1"><emu-t>np</emu-t><wbr>​<emu-t>np</emu-t><wbr>​</emu-rhs>
 </emu-production></emu-grammar>
 </body>


### PR DESCRIPTION
From tc39/ecma262#64

I'm sorry, the `::after` way did not work as expected in IE.
So I had been investicating other approach.

I chose inserting a `<wbr>` and a `\u200B` (a zero-width space).

- IE11 makes new line at a `\u200B`, but not at `<wbr>`.
- Chrome makes new line at `<wbr>`, but not at a `\u200B` (2000-200B are the same. [it's a bug](https://code.google.com/p/chromium/issues/detail?id=60452)).
- Firefox makes new line at a `\u200B` or `<wbr>`.

It inserts those to after `<emu-t>` and `<emu-nt>`.
Because IE does not make new line if it inserted those to inside of `<emu-t>` and `<emu-nt>`. (I think it's a correct behavior)