### PR TITLE
Update emu-t and emu-nt for line breaks

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -149,8 +149,10 @@ emu-oneof {
 }
 
 emu-nt {
+    display: inline-block;
     font-style: italic;
     white-space: nowrap;
+    text-indent: 0;
 }
 
 emu-nt a, emu-nt a:visited {
@@ -162,8 +164,11 @@ emu-rhs emu-nt {
 }
 
 emu-t {
+    display: inline-block;
     font-family: monospace;
     font-weight: bold;
+    white-space: nowrap;
+    text-indent: 0;
 }
 
 emu-production emu-t {


### PR DESCRIPTION
From tc39/ecma262#64

The `::after` way did not work as expected in IE, because `<emu-t>` and `<emu-nt>` are `inline` element.
I modified these elements to `inline-block`, then browsers make new line at the border of blocks if it's overflowed.
This way needed resetting `text-indent`, because this style is inherited from parent and `<emu-rhs>` has `text-indent: -25px;`.