### PR TITLE
Minor tweaks to document options table

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -56,9 +56,9 @@ ecmarkup spec.html out.html
         <tr><td>title</td><td>Title of specification, for example `ECMAScript 2016` or `Async Functions`.</td></tr>
         <tr><td>status</td><td>Status of specification. Can be `proposal`, `draft`, or `standard`. Default is `proposal`.</td></tr>
         <tr><td>stage</td><td>Stage of proposal. Must be a number if provided, but is optional. Sets `version` to `Stage N Draft`, but can be overridden.</td></tr>
-        <tr><td>version</td><td>Version of specification, for example `6<sup>th</sup> Edition` or `Draft 1`. Optional.</td></tr>
+        <tr><td>version</td><td>Version of specification, for example `6&lt;sup>th&lt;/sup> Edition` or `Draft 1`. Optional.</td></tr>
         <tr><td>shortname</td><td>Shortname of specification, for example `ECMA-262` or `ECMA-402`.</td></tr>
-        <tr><td>location</td><td>Href of this specification. Use in conjunction with the biblio file to enable external specs to reference this one.</td></tr>
+        <tr><td>location</td><td>URL of this specification. Use in conjunction with the biblio file to enable external specs to reference this one.</td></tr>
         <tr><td>toc</td><td>Emit table of contents. Boolean, default true.</td></tr>
         <tr><td>old-toc</td><td>Emit the old style of table of contents. Boolean, default false.</td></tr>
       </table>


### PR DESCRIPTION
Note: I just used the GitHub web interface and didn't test locally, so the `<` -> `&lt;` change might be borked. Seems like an Ecmarkdown bug from the broken expectations side of things at least.