### PR TITLE
Fix all-inline rendering of productions in Note in 11.9.1

### DIFF
--- a/lib/Production.js
+++ b/lib/Production.js
@@ -96,7 +96,7 @@ module.exports = class Production extends Builder {
       parent = parent.parentNode;
     }
 
-    return ['EMU-ANNEX', 'EMU-CLAUSE', 'EMU-INTRO', 'BODY'].indexOf(parent.nodeName) === -1;
+    return ['EMU-ANNEX', 'EMU-CLAUSE', 'EMU-INTRO', 'EMU-NOTE', 'BODY'].indexOf(parent.nodeName) === -1;
   }
 };
 


### PR DESCRIPTION
... (Rules of Automatic Semicolon Insertion).

(see http://tc39.github.io/ecma262/#sec-rules-of-automatic-semicolon-insertion)