### PR TITLE
Link directly to <dfn>s if they have an ID

### DIFF
--- a/lib/Dfn.js
+++ b/lib/Dfn.js
@@ -5,12 +5,21 @@ const parent = require('./utils').parent;
 
 module.exports = class Dfn extends Builder {
   build() {
-    const parentClause = parent(this.node, ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX']);
-    if (!parentClause) return;
+    const id = getClosestId(this.node);
+    if (!id) return;
 
     this.spec.biblio.terms[this.node.textContent] = {
-      id: parentClause.id,
+      id: id,
       location: ''
     };
   }
 };
+
+function getClosestId(node) {
+  if (node.id) return node.id;
+
+  const parentClause = parent(node, ['EMU-CLAUSE', 'EMU-INTRO', 'EMU-ANNEX']);
+  if (!parentClause) return null;
+
+  return parentClause.id;
+}

--- a/lib/Spec.js
+++ b/lib/Spec.js
@@ -411,7 +411,7 @@ module.exports = class Spec {
   }
 
   lookupBiblioEntryById(id) {
-    const types = ['clause', 'production', 'example', 'note', 'figure', 'table'];
+    const types = ['clause', 'production', 'example', 'note', 'figure', 'table', 'term'];
 
     for (let i = 0; i < types.length; i++) {
       const type = types[i];
@@ -484,7 +484,7 @@ function autolink(replacer, autolinkmap, spec, node, parentId, allowSameId) {
     const content = escape(node.textContent);
     const autolinked = content.replace(replacer, function (match) {
       const entry = autolinkmap[match];
-      if ((!entry || entry.id === parentId) && !allowSameId) {
+      if ((!entry || entry.id === parentId || entry.id === node.parentElement.id) && !allowSameId) {
         return match;
       }
 

--- a/lib/Xref.js
+++ b/lib/Xref.js
@@ -51,6 +51,9 @@ module.exports = class Xref extends Builder {
       case 'figure':
         buildFigureLink(this.spec, xref, entry.entry, 'Figure');
         break;
+      case 'term':
+        buildTermLink(this.spec, xref, entry.entry);
+        break;
       default:
         utils.logWarning('found unknown biblio entry (this is a bug, please file it)');
       }
@@ -123,7 +126,10 @@ function buildFigureLink(spec, xref, entry, type) {
   }
 }
 
+function buildTermLink(spec, xref, entry) {
+  xref.innerHTML = buildXrefLink(entry, xref.innerHTML);
+}
+
 function buildXrefLink(entry, contents) {
   return '<a href="' + entry.location + '#' + entry.id + '">' + contents + '</a>';
-
 }

--- a/test/dfn.html
+++ b/test/dfn.html
@@ -10,7 +10,9 @@ copyright: false
 <emu-clause id="sec-dfn">
   <h1>dfn</h1>
 
-  <p>The term <dfn>dfn</dfn> means the dfn tag. Other mentions of dfn in this clause should not be auto-linked.</p>
+  <p>The term <dfn>dfn</dfn> means the dfn tag. Other mentions of dfn in this clause should be auto-linked as of v2.8.2.</p>
+
+  <p>The term <dfn id="dfn2">dfn2</dfn> should have any links go directly to it.</p>
 
   <emu-clause id="sec-dfn-subclause">
     <h1>dfn subclause</h1>
@@ -20,11 +22,12 @@ copyright: false
 
   <p>Also terms are auto-linked in algorithms. But not naked abstract ops!</p>
 
-  <!-- these shouldn't autolink as they are under the same clause that defines the dfn -->
+  <!-- these should autolink even though they are under the same clause that defines the dfn -->
   <emu-alg>
     1. Call the dfn algorithm.
     2. Do something great with dfn.
     3. dfn is now awesome.
+    4. dfn2 goes to the ID directly.
   </emu-alg>
 
   <emu-clause id="sec-dfn-autolink">
@@ -35,6 +38,7 @@ copyright: false
       1. Call the dfn algorithm.
       2. Do something great with dfn.
       3. dfn is now awesome.
+      4. dfn2 goes to the ID directly.
     </emu-alg>
   </emu-clause>
 </emu-clause>

--- a/test/dfn.html.baseline
+++ b/test/dfn.html.baseline
@@ -8,7 +8,9 @@
 <emu-clause id="sec-dfn">
   <h1><span class="secnum">1</span>dfn<span class="utils"><span class="anchor"><a href="#sec-dfn">#</a></span></span></h1>
 
-  <p>The term  <dfn>dfn</dfn> means the dfn tag. Other mentions of dfn in this clause should not be auto-linked.</p>
+  <p>The term  <dfn>dfn</dfn> means the dfn tag. Other mentions of dfn in this clause should be auto-linked as of v2.8.2.</p>
+
+  <p>The term  <dfn id="dfn2">dfn2</dfn> should have any links go directly to it.</p>
 
   <emu-clause id="sec-dfn-subclause">
     <h1><span class="secnum">1.1</span>dfn subclause<span class="utils"><span class="anchor"><a href="#sec-dfn-subclause">#</a></span></span></h1>
@@ -18,15 +20,15 @@
 
   <p>Also terms are auto-linked in algorithms. But not naked abstract ops!</p>
 
-  <!-- these shouldn't autolink as they are under the same clause that defines the dfn -->
-  <emu-alg><ol><li>Call the <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> algorithm.</li><li>Do something great with <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref>.</li><li><emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> is now awesome.
+  <!-- these should autolink even though they are under the same clause that defines the dfn -->
+  <emu-alg><ol><li>Call the <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> algorithm.</li><li>Do something great with <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref>.</li><li><emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> is now awesome.</li><li><emu-xref href="#dfn2"><a href="#dfn2">dfn2</a></emu-xref> goes to the ID directly.
   </li></ol></emu-alg>
 
   <emu-clause id="sec-dfn-autolink">
     <h1><span class="secnum">1.2</span>dfn autolink<span class="utils"><span class="anchor"><a href="#sec-dfn-autolink">#</a></span></span></h1>
 
     <!-- these should autolink -->
-    <emu-alg><ol><li>Call the <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> algorithm.</li><li>Do something great with <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref>.</li><li><emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> is now awesome.
+    <emu-alg><ol><li>Call the <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> algorithm.</li><li>Do something great with <emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref>.</li><li><emu-xref href="#sec-dfn"><a href="#sec-dfn">dfn</a></emu-xref> is now awesome.</li><li><emu-xref href="#dfn2"><a href="#dfn2">dfn2</a></emu-xref> goes to the ID directly.
     </li></ol></emu-alg>
   </emu-clause>
 </emu-clause>


### PR DESCRIPTION
Fixes #68.

This was trickier than expected because of the way autolinking always indirects through creating an emu-xref to the section whose innerHTML is `<a href="#section-id">term</a>`. So I had to extend emu-xref to also allow emu-xrefs directly to terms, with innerHTML `<a href="#term-id">term</a>`.

That seems kind of weird, and an alternate approach would be for autolinking to not create emu-xref wrappers for dfns, or at least not for dfns that have their own IDs. Let me know which you prefer.