### PR TITLE
Unescape ampersands

### DIFF
--- a/lib/Grammar.js
+++ b/lib/Grammar.js
@@ -11,7 +11,7 @@ module.exports = class Grammar extends Builder {
     let content = this.node.innerHTML;
     // hack - grammarkdown doesn't handle html entities but most usages of
     // ecmarkup use &lt; and &gt; extensively in emu-gramar (eg. lookaheads)
-    content = content.replace(/&gt;/g, '>').replace(/&lt;/g, '<');
+    content = content.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
     this.node.innerHTML = gmdCompile(content);
   }
 };

--- a/test/grammar.html
+++ b/test/grammar.html
@@ -16,7 +16,7 @@ copyright: false
   </ins>
 
   LookaheadExample ::
-    `n` [lookahead <! {`1`, `3`, `5`, `7`, `9`}] DecimalDigits
+    `&&` `n` [lookahead <! {`1`, `3`, `5`, `7`, `9`}] DecimalDigits
     DecimalDigit [lookahead <! DecimalDigit]
 </emu-grammar>
 

--- a/test/grammar.html.baseline
+++ b/test/grammar.html.baseline
@@ -12,7 +12,7 @@
     <emu-nt><a href="#prod-NewTerminal">NewTerminal</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="b1b8622b"><emu-t>t</emu-t></emu-rhs>
 </emu-production></ins>
 <emu-production name="LookaheadExample" type="lexical" id="prod-LookaheadExample">
-    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="f0e1865a"><emu-t>n</emu-t><emu-gann>[lookahead ∉ 
+    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="cada3c85"><emu-t>&amp;&amp;</emu-t><emu-t>n</emu-t><emu-gann>[lookahead ∉ 
         <emu-t>1</emu-t>]</emu-gann></emu-rhs>
     <emu-rhs a="195cbc6c"><emu-nt><a href="https://tc39.github.io/ecma262/#prod-DecimalDigit">DecimalDigit</a></emu-nt><emu-gann>[lookahead ∉ <emu-nt><a href="https://tc39.github.io/ecma262/#prod-DecimalDigit">DecimalDigit</a></emu-nt>]</emu-gann></emu-rhs>
 </emu-production></emu-grammar></body>


### PR DESCRIPTION
Hey Brian!

Please, take a look at [this section](https://tc39.github.io/ecma262/#sec-binary-logical-operators). Ampersands in `<emu-grammar>` are escaped twice. This PR fixes it by unescaping them, along with `>` and `<`.