### PR TITLE
Async Functions, Cancellation, and updated Grammarkdown

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,6 @@
     "command": "tsc",
     "isShellCommand": true,
     "args": ["-p", "src"],
-    "showOutput": "silent",
+    "showOutput": "always",
     "problemMatcher": "$tsc"
 }

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
   "author": "Brian Terlson",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.0.6",
     "chalk": "^1.1.1",
     "ecmarkdown": "^3.0.9",
-    "grammarkdown": "^1.0.2",
+    "grammarkdown": "^1.0.5",
     "highlight.js": "^9.0.0",
     "html-escape": "^1.0.2",
     "js-yaml": "^3.4.6",
     "jsdom": "^9.0.0",
     "nomnom": "^1.8.1",
+    "prex": "^0.2.0",
     "promise-debounce": "^1.0.1"
   },
   "devDependencies": {

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -5,7 +5,7 @@ import emd = require('ecmarkdown');
 class Algorithm extends Builder {
   build() {
     const contents = this.node.innerHTML;
-    let html = emd.document(contents);
+    const html = emd.document(contents);
     this.node.innerHTML = html;
   }
 }

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -1,27 +1,78 @@
 import Builder = require('./Builder');
-import gmd = require('grammarkdown');
-import GrammarFile = gmd.Grammar;
-import EmitFormat = gmd.EmitFormat;
-const uncollapsedRe = /:.*\r?\n.*[^\s]+.*(\r?\n|$)/;
+import jsdom = require('jsdom');
+import { Host, CompilerOptions, Grammar as GrammarFile, EmitFormat } from 'grammarkdown';
+
+const endTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/i;
+const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/ig;
+const entityRe = /&(gt|lt|amp);/g;
+const entities: { [key: string]: string } = {
+  "&gt;": ">",
+  "&lt;": "<",
+  "&amp;": "&"
+};
 
 /*@internal*/
 class Grammar extends Builder {
   build() {
-    let content: string = this.node.innerHTML;
-    // hack - grammarkdown doesn't handle html entities but most usages of
-    // ecmarkup use &lt; and &gt; extensively in emu-grammar (eg. lookaheads)
-    content = content.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
-    this.node.innerHTML = gmdCompile(content);
-  }
-}
+    let content: string;
+    let possiblyMalformed = true;
+    if (this.spec.sourceText) {
+      // If the source text is available, we should use it since `innerHTML` serializes the
+      // DOM tree beneath the node. This can result in odd behavior when the syntax is malformed
+      // in a way that parse5 does not understand, but grammarkdown could possibly recover.
+      const location = jsdom.nodeLocation(this.node);
+      if (location.startTag && location.endTag) {
+        // the parser was able to find a matching end tag.
+        const start = location.startTag.end as number;
+        const end = location.endTag.start as number;
+        content = this.spec.sourceText.slice(start, end);
+      }
+      else {
+        // the parser was *not* able to find a matching end tag. Try to recover by finding a
+        // possible end tag, otherwise read the rest of the source text.
+        const start = globalEndTagRe.lastIndex = location.end as number;
+        const match = globalEndTagRe.exec(this.spec.sourceText);
+        const end = match ? match.index : this.spec.sourceText.length;
+        content = this.spec.sourceText.slice(start, end);
 
-function gmdCompile(text: string) {
-  let out: string | undefined = undefined;
-  function readFile(file: string) { return text; }
-  function writeFile(file: string, output: string) { out = output; }
-  const g = new GrammarFile(['file.grammar'], { format: EmitFormat.ecmarkup }, readFile);
-  g.emit(undefined, writeFile);
-  return out!;
+        // since we already tested for an end tag, no need to test again later.
+        possiblyMalformed = false;
+        globalEndTagRe.lastIndex = 0;
+      }
+    }
+    else {
+      // no source text, so read innerHTML as a fallback.
+      content = this.node.innerHTML;
+    }
+
+    if (possiblyMalformed) {
+      // check for a possible end-tag in the content. For now we only check for a few possible
+      // recovery cases, namely emu-* tags, and a few block-level elements.
+      const match = endTagRe.exec(content);
+      if (match) {
+        content = content.slice(0, match.index);
+      }
+    }
+
+    // grammarkdown doesn't handle html entities but most usages of
+    // ecmarkup use &lt; and &gt; extensively in emu-grammar (eg. lookaheads)
+    content = content.replace(entityRe, entity => entities[entity]);
+
+    const host = Host.getHost({
+      readFile: file => content,
+      writeFile: (_, output) => content = output
+    });
+
+    const options: CompilerOptions = {
+      format: EmitFormat.ecmarkup,
+      noChecks: true
+    };
+
+    const grammar = new GrammarFile(['file.grammar'], options, host, /*oldGrammar*/ undefined, this.spec.cancellationToken);
+    grammar.emit(); // updates content
+
+    this.node.innerHTML = content;
+  }
 }
 
 /*@internal*/

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -1,33 +1,30 @@
 import utils = require('./utils');
 import Path = require('path');
-import Promise = require('bluebird');
 import Builder = require('./Builder');
 
 /*@internal*/
 class Import extends Builder {
-  build(rootDir: string): PromiseLike<any> {
+  async build(rootDir: string) {
     const href = this.node.getAttribute('href');
     const importPath = Path.join(rootDir || this.spec.rootDir, href);
     this.spec.imports.push(importPath);
 
-    return this.spec.fetch(importPath)
-      .then(utils.htmlToDoc)
-      .then(importDoc => {
-        const nodes = importDoc.body.childNodes;
-        const parent = this.node.parentNode;
-        const frag = this.spec.doc.createDocumentFragment();
+    const html = await this.spec.fetch(importPath);
+    const importDoc = await utils.htmlToDoc(html);
+    const nodes = importDoc.body.childNodes;
+    const parent = this.node.parentNode;
+    const frag = this.spec.doc.createDocumentFragment();
 
-        for (let i = 0; i < nodes.length; i++) {
-          const node = nodes[i];
-          const importedNode = this.spec.doc.importNode(node, true);
-          frag.appendChild(importedNode);
-        }
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      const importedNode = this.spec.doc.importNode(node, true);
+      frag.appendChild(importedNode);
+    }
 
-        const imports = frag.querySelectorAll('emu-import') as NodeListOf<HTMLElement>;
-        this.node.appendChild(frag);
+    const imports = frag.querySelectorAll('emu-import') as NodeListOf<HTMLElement>;
+    this.node.appendChild(frag);
 
-        return this.spec.buildAll(imports, Import, { buildArgs: [Path.dirname(importPath)] });
-      });
+    await this.spec.buildAll(imports, Import, { buildArgs: [Path.dirname(importPath)] });
   }
 }
 

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -2,6 +2,7 @@ import Spec = require('./Spec');
 import Biblio = require('./Biblio');
 import BiblioEntry = Biblio.BiblioEntry;
 import utils = require('./utils');
+import { CancellationToken } from 'prex';
 
 export { Spec, BiblioEntry };
 
@@ -20,10 +21,10 @@ export interface Options {
     verbose?: boolean;
 }
 
-export function build(path: string, fetch: (path: string) => PromiseLike<string>, opts?: Options): PromiseLike<Spec> {
-  return fetch(path)
-    .then(utils.htmlToDoc)
-    .then(doc => {
-      return new Spec(path, fetch, doc, opts).build();
-    });
+export async function build(path: string, fetch: (path: string, token: CancellationToken) => PromiseLike<string>, opts?: Options, token = CancellationToken.none): Promise<Spec> {
+  const html = await fetch(path, token);
+  const doc = utils.htmlToDoc(html);
+  const spec = new Spec(path, fetch, doc, opts, /*sourceText*/ html, token);
+  await spec.build();
+  return spec;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import jsdom = require('jsdom');
-import Promise = require('bluebird');
 import chalk = require('chalk');
 import Spec = require("./Spec");
 import Clause = require("./Clause");
@@ -9,12 +8,7 @@ export const CLAUSE_ELEMS = ['EMU-INTRO', 'EMU-CLAUSE', 'EMU-ANNEX'];
 
 /*@internal*/
 export function htmlToDoc(html: string) {
-  return new Promise<HTMLDocument>((res, rej) => {
-    jsdom.env(html, (err, window) => {
-      if (err) return rej(err);
-      res(window.document);
-    });
-  });
+  return jsdom.jsdom(html);
 }
 
 /*@internal*/

--- a/test/build.js
+++ b/test/build.js
@@ -1,6 +1,5 @@
 'use strict';
 const assert = require('assert');
-const Promise = require('bluebird');
 
 const build = require('../lib/ecmarkup').build;
 

--- a/test/grammar.html.baseline
+++ b/test/grammar.html.baseline
@@ -12,7 +12,6 @@
     <emu-nt><a href="#prod-NewTerminal">NewTerminal</a></emu-nt><emu-geq>:</emu-geq><emu-rhs a="b1b8622b"><emu-t>t</emu-t></emu-rhs>
 </emu-production></ins>
 <emu-production name="LookaheadExample" type="lexical" id="prod-LookaheadExample">
-    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="cada3c85"><emu-t>&amp;&amp;</emu-t><emu-t>n</emu-t><emu-gann>[lookahead ∉ 
-        <emu-t>1</emu-t>]</emu-gann></emu-rhs>
+    <emu-nt><a href="#prod-LookaheadExample">LookaheadExample</a></emu-nt><emu-geq>::</emu-geq><emu-rhs a="d9a654c9"><emu-t>&amp;&amp;</emu-t><emu-t>n</emu-t><emu-gann>[lookahead ∉ { <emu-t>1</emu-t>, <emu-t>3</emu-t>, <emu-t>5</emu-t>, <emu-t>7</emu-t>, <emu-t>9</emu-t> }]</emu-gann><emu-nt><a href="https://tc39.github.io/ecma262/#prod-DecimalDigits">DecimalDigits</a></emu-nt></emu-rhs>
     <emu-rhs a="195cbc6c"><emu-nt><a href="https://tc39.github.io/ecma262/#prod-DecimalDigit">DecimalDigit</a></emu-nt><emu-gann>[lookahead ∉ <emu-nt><a href="https://tc39.github.io/ecma262/#prod-DecimalDigit">DecimalDigit</a></emu-nt>]</emu-gann></emu-rhs>
 </emu-production></emu-grammar></body>

--- a/test/output.js
+++ b/test/output.js
@@ -1,8 +1,6 @@
 'use strict';
 const fs = require('fs');
 const assert = require('assert');
-const Promise = require('bluebird');
-const readFile = Promise.promisify(fs.readFile);
 const diff = require('diff');
 
 const emu = require('../lib/ecmarkup');
@@ -12,7 +10,9 @@ const files = fs.readdirSync('test')
 
 function build(file) {
   return emu.build(file, function (file) {
-    return readFile(file, 'utf-8');
+    return new Promise((resolve, reject) =>
+      fs.readFile(file, 'utf-8', (err, data) =>
+        err ? reject(err) : resolve(data)));
   });
 }
 


### PR DESCRIPTION
This PR has the following changes:

* Switched from `bluebird` to native ES6 promises.
* Switched from `.then` continuations to async functions.
* Added `prex` to support cancellation.
* Updated to `grammarkdown` 1.0.5.
* Added logic to the `Grammar` builder to be more tolerant to malformed grammar resulting from how jsdom/parse5 parses HTML. This is primarily to be more reliable when rendering previews following edits in the middle of a document in the `ecmarkup-vscode` extension.