### PR TITLE
Patch __awaiter to use bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Brian Terlson",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.4.5",
     "chalk": "^1.1.1",
     "ecmarkdown": "^3.0.9",
     "grammarkdown": "^1.0.5",
@@ -41,7 +42,7 @@
     "promise-debounce": "^1.0.1"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.0.31",
+    "@types/bluebird": "^3.0.32",
     "@types/chalk": "^0.4.28",
     "@types/highlight.js": "^9.1.7",
     "@types/js-yaml": "^3.5.27",

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -1,6 +1,7 @@
 import utils = require('./utils');
 import Path = require('path');
 import Builder = require('./Builder');
+var __awaiter = require("./awaiter");
 
 /*@internal*/
 class Import extends Builder {

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -26,6 +26,7 @@ import Figure = require('./Figure');
 import Biblio = require('./Biblio');
 import autolinker = require('./autolinker');
 import { CancellationToken } from 'prex';
+var __awaiter = require("./awaiter");
 
 const DRAFT_DATE_FORMAT = { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' };
 const STANDARD_DATE_FORMAT = { year: 'numeric', month: 'long', timeZone: 'UTC' };

--- a/src/awaiter.ts
+++ b/src/awaiter.ts
@@ -1,6 +1,4 @@
 import Promise = require("bluebird");
 export = function (thisArg: any, _arguments: any, P: PromiseConstructorLike, generator: any) {
-  return (<any>Promise).coroutine(generator, {
-    yieldHandler(value: any) { return Promise.cast(value); }
-  }).apply(thisArg, _arguments);
+  return (<any>Promise).coroutine(generator, { yieldHandler: Promise.cast }).apply(thisArg, _arguments);
 };

--- a/src/awaiter.ts
+++ b/src/awaiter.ts
@@ -1,0 +1,10 @@
+import Promise = require("bluebird");
+
+export = function (thisArg: any, _arguments: any, P: PromiseConstructorLike, generator: any) {
+    return new (P || (P = Promise))<any>(function (resolve, reject) {
+        function fulfilled(value: any) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value: any) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result: any) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};

--- a/src/awaiter.ts
+++ b/src/awaiter.ts
@@ -1,10 +1,6 @@
 import Promise = require("bluebird");
-
 export = function (thisArg: any, _arguments: any, P: PromiseConstructorLike, generator: any) {
-    return new (P || (P = Promise))<any>(function (resolve, reject) {
-        function fulfilled(value: any) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value: any) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
-        function step(result: any) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments)).next());
-    });
+  return (<any>Promise).coroutine(generator, {
+    yieldHandler(value: any) { return Promise.cast(value); }
+  }).apply(thisArg, _arguments);
 };

--- a/src/awaiter.ts
+++ b/src/awaiter.ts
@@ -1,4 +1,11 @@
 import Promise = require("bluebird");
+
+/**
+ * Patch for TypeScript's __awaiter helper. While generally unsupported, it is acceptable to
+ * use custom helpers to override TypeScript runtime behavior in a compatible fashion.
+ *
+ * https://github.com/Microsoft/TypeScript/issues/6737#issuecomment-177007790
+ */
 export = function (thisArg: any, _arguments: any, P: PromiseConstructorLike, generator: any) {
   return (<any>Promise).coroutine(generator, { yieldHandler: Promise.cast }).apply(thisArg, _arguments);
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import path = require('path');
 import fs = require('fs');
 import utils = require('./utils');
 import debounce = require('promise-debounce');
+var __awaiter = require("./awaiter");
 
 const jsDependencies = ['menu.js', 'findLocalReferences.js'];
 

--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -3,6 +3,7 @@ import Biblio = require('./Biblio');
 import BiblioEntry = Biblio.BiblioEntry;
 import utils = require('./utils');
 import { CancellationToken } from 'prex';
+var __awaiter = require("./awaiter");
 
 export { Spec, BiblioEntry };
 


### PR DESCRIPTION
Keep in mind that even with this patch, the return **type** of an async function will still be the ES6 Promise, even though the runtime value will be a bluebird Promise.