### PR TITLE
override padding-left and margin-left in inline emu-production

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -167,19 +167,16 @@ emu-production {
     margin-left: 5ex;
 }
 
-
 emu-grammar.inline, emu-production.inline,
-emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs {
-  display: inline;
+emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
+emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
+    display: inline;
+    padding-left: 1ex;
+    margin-left: 0;
 }
 
 emu-grammar[collapsed] emu-production, emu-production[collapsed] {
     margin: 0;
-}
-
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: 1ex;
 }
 
 emu-constraints {


### PR DESCRIPTION
Before:

<img width="960" alt="screen shot 2017-01-21 at 11 00 22" src="https://cloud.githubusercontent.com/assets/218840/22176913/eb71f2ec-dfc8-11e6-9842-6e25ad0bfd36.png">

After:

<img width="960" alt="screen shot 2017-01-21 at 10 59 57" src="https://cloud.githubusercontent.com/assets/218840/22176914/f085eb8a-dfc8-11e6-88c8-ab237721da7a.png">
