### PR TITLE
highlight full-row table insertions/deletions as such

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -435,6 +435,18 @@ emu-grammar > ins, emu-grammar > del {
   display: block;
 }
 
+tr.ins > td > ins {
+  border-bottom: none;
+}
+
+tr.ins > td {
+  background-color: #e0f8e0;
+}
+
+tr.del > td {
+  background-color: #fee;
+}
+
 /* Menu Styles */
 #menu-toggle {
   font-size: 2em;


### PR DESCRIPTION
With `<tr class="ins">`.

Before:

<img width="938" alt="before" src="https://cloud.githubusercontent.com/assets/218840/22629177/ed8b28e0-eb95-11e6-9927-1e0827fb88a1.png">

After:

<img width="948" alt="after" src="https://cloud.githubusercontent.com/assets/218840/22629176/e9875034-eb95-11e6-96ca-2bca9663152b.png">