### PR TITLE
Update grammar to support `&ldquo;` and `&rdquo;`

### DIFF
--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -11,7 +11,7 @@ const entities: { [key: string]: string } = {
   "&lt;": "<",
   "&amp;": "&",
   "&ldquo;": "\u201C",
-  "&rdquo;": \u201D",
+  "&rdquo;": "\u201D",
 };
 
 /*@internal*/

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -5,13 +5,13 @@ import { Context } from './Context';
  
 const endTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/i;
 const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/ig;
-const entityRe = /&(gt|lt|amp|(l|r)dquo);/g;
+const entityRe = /&(gt|lt|amp|[lr]dquo);/g;
 const entities: { [key: string]: string } = {
   "&gt;": ">",
   "&lt;": "<",
   "&amp;": "&",
-  "&ldquo;": "“",
-  "&rdquo;": "”",
+  "&ldquo;": "\u201C",
+  "&rdquo;": \u201D",
 };
 
 /*@internal*/

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -5,11 +5,13 @@ import { Context } from './Context';
  
 const endTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/i;
 const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/ig;
-const entityRe = /&(gt|lt|amp);/g;
+const entityRe = /&(gt|lt|amp|(l|r)dquo);/g;
 const entities: { [key: string]: string } = {
   "&gt;": ">",
   "&lt;": "<",
-  "&amp;": "&"
+  "&amp;": "&",
+  "&ldquo;": "“",
+  "&rdquo;": "”",
 };
 
 /*@internal*/


### PR DESCRIPTION
There are some instances where `&ldquo;` and `&rdquo;` are used within grammars.

This includes:

- https://tc39.github.io/ecma262/#prod-UnicodeIDStart
- https://tc39.github.io/ecma262/#prod-UnicodeIDContinue

This PR fixes these issues by allowing both entities.