### PR TITLE
Hide #menu-toggle for print styles

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -898,3 +898,9 @@ li.menu-search-result-term:before {
   text-align: right;
   padding-right: 5px;
 }
+
+@media print {
+  #menu-toggle {
+    display: none; 
+  }
+}


### PR DESCRIPTION
This makes the print output look good. Print PDFs can now be generated with the following command:

```sh
chrome --headless --disable-gpu --print-to-pdf 'https://tc39.github.io/ecma262/'
```