### PR TITLE
Allow custom copyright boilerplates. (Enables use for non-Ecma specs)

### DIFF
--- a/src/ecmarkup.ts
+++ b/src/ecmarkup.ts
@@ -7,23 +7,30 @@ var __awaiter = require('./awaiter');
 
 export { Spec, BiblioEntry };
 
+export class Boilerplate {
+  address?: string;
+  copyright?: string;
+  license?: string;
+}
+
 export interface Options {
-    status?: "proposal" | "draft" | "standard";
-    version?: string;
-    title?: string;
-    shortname?: string;
-    stage?: string | null;
-    copyright?: boolean;
-    date?: Date;
-    location?: string;
-    contributors?: string;
-    toc?: boolean;
-    oldToc?: boolean;
-    verbose?: boolean;
-    cssOut?: string;
-    jsOut?: string;
-    assets?: "none" | "inline";
-    outfile?: string;
+  status?: "proposal" | "draft" | "standard";
+  version?: string;
+  title?: string;
+  shortname?: string;
+  stage?: string | null;
+  copyright?: boolean;
+  date?: Date;
+  location?: string;
+  contributors?: string;
+  toc?: boolean;
+  oldToc?: boolean;
+  verbose?: boolean;
+  cssOut?: string;
+  jsOut?: string;
+  assets?: "none" | "inline";
+  outfile?: string;
+  boilerplate?: Boilerplate;
 }
 
 export async function build(path: string, fetch: (path: string, token: CancellationToken) => PromiseLike<string>, opts?: Options, token = CancellationToken.none): Promise<Spec> {

--- a/test/boilerplate-address.fixture
+++ b/test/boilerplate-address.fixture
@@ -1,0 +1,6 @@
+<p class="ECMAaddress">Tet Corporation</p>
+<p class="ECMAaddress">2 Hammarskjöld Plaza</p>
+<p class="ECMAaddress">New York City, New York</p>
+<p class="ECMAaddress">Tel: 123-456-7890</p>
+<p class="ECMAaddress">Fax: 123-456-7890</p>
+<p class="ECMAaddress">Web: <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>

--- a/test/boilerplate-address.html
+++ b/test/boilerplate-address.html
@@ -1,0 +1,13 @@
+<pre class=metadata>
+title:     test title!
+toc:       false
+date:      2018-04-02
+assets:    none
+stage:     0
+status:    draft
+contributors: Rick Waldron, Mid-World
+copyright: true
+boilerplate:
+  address: test/boilerplate-address.fixture
+</pre>
+

--- a/test/boilerplate-address.html.baseline
+++ b/test/boilerplate-address.html.baseline
@@ -1,0 +1,37 @@
+<!doctype html>
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="spec-container"><h1 class="title first">test title!</h1>
+
+<emu-annex id="sec-copyright-and-software-license">
+      <h1><span class="secnum">A</span>Copyright &amp; Software License</h1>
+      <p class="ECMAaddress">Tet Corporation</p>
+<p class="ECMAaddress">2 Hammarskjöld Plaza</p>
+<p class="ECMAaddress">New York City, New York</p>
+<p class="ECMAaddress">Tel: 123-456-7890</p>
+<p class="ECMAaddress">Fax: 123-456-7890</p>
+<p class="ECMAaddress">Web:  <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
+
+      <h2>Copyright Notice</h2>
+      <p>© 2018 Ecma International</p>
+
+<p>This draft document may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published, and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this section are included on all such copies and derivative works. However, this document itself may not be modified in any way, including by removing the copyright notice or references to Ecma International, except as needed for the purpose of developing any document or deliverable produced by Ecma International.</p>
+
+<p>This disclaimer is valid only prior to final version of this document. After approval all rights on the standard are reserved by Ecma International.</p>
+
+<p>The limited permissions are granted through the standardization phase and will not be revoked by Ecma International or its successors or assigns during this time.</p>
+
+<p>This document and the information contained herein is provided on an "AS IS" basis and ECMA INTERNATIONAL DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.</p>
+
+      <h2>Software License</h2>
+      <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT https://ecma-international.org/memento/codeofconduct.htm FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+
+<p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
+
+<ol>
+  <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+  <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+  <li>Neither the name of the authors nor Ecma International may be used to endorse or promote products derived from this software without specific prior written permission.</li>
+</ol>
+
+<p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+
+    </emu-annex></div></body>

--- a/test/boilerplate-all.html
+++ b/test/boilerplate-all.html
@@ -1,0 +1,15 @@
+<pre class=metadata>
+title:     test title!
+toc:       false
+date:      2018-04-02
+assets:    none
+stage:     0
+status:    draft
+contributors: Rick Waldron, Mid-World
+copyright: true
+boilerplate:
+  address: test/boilerplate-address.fixture
+  copyright: test/boilerplate-copyright.fixture
+  license: test/boilerplate-license.fixture
+</pre>
+

--- a/test/boilerplate-all.html.baseline
+++ b/test/boilerplate-all.html.baseline
@@ -1,0 +1,23 @@
+<!doctype html>
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="spec-container"><h1 class="title first">test title!</h1>
+
+<emu-annex id="sec-copyright-and-software-license">
+      <h1><span class="secnum">A</span>Copyright &amp; Software License</h1>
+      <p class="ECMAaddress">Tet Corporation</p>
+<p class="ECMAaddress">2 Hammarskjöld Plaza</p>
+<p class="ECMAaddress">New York City, New York</p>
+<p class="ECMAaddress">Tel: 123-456-7890</p>
+<p class="ECMAaddress">Fax: 123-456-7890</p>
+<p class="ECMAaddress">Web:  <a href="http://www.tet-corporation.com/">http://www.tet-corporation.com/</a></p>
+
+      <h2>Copyright Notice</h2>
+      <p>© 2018 Rick Waldron, Mid-World</p>
+
+      <h2>Software License</h2>
+      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+<p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+
+    </emu-annex></div></body>

--- a/test/boilerplate-copyright.fixture
+++ b/test/boilerplate-copyright.fixture
@@ -1,0 +1,1 @@
+<p>© !YEAR! !CONTRIBUTORS!</p>

--- a/test/boilerplate-copyright.html
+++ b/test/boilerplate-copyright.html
@@ -1,0 +1,13 @@
+<pre class=metadata>
+title:     test title!
+toc:       false
+date:      2018-04-02
+assets:    none
+stage:     0
+status:    draft
+contributors: Rick Waldron, Mid-World
+copyright: true
+boilerplate:
+  copyright: test/boilerplate-copyright.fixture
+</pre>
+

--- a/test/boilerplate-copyright.html.baseline
+++ b/test/boilerplate-copyright.html.baseline
@@ -1,0 +1,29 @@
+<!doctype html>
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="spec-container"><h1 class="title first">test title!</h1>
+
+<emu-annex id="sec-copyright-and-software-license">
+      <h1><span class="secnum">A</span>Copyright &amp; Software License</h1>
+      <p class="ECMAaddress">Ecma International</p>
+<p class="ECMAaddress">Rue du Rhone 114</p>
+<p class="ECMAaddress">CH-1204 Geneva</p>
+<p class="ECMAaddress">Tel: +41 22 849 6000</p>
+<p class="ECMAaddress">Fax: +41 22 849 6001</p>
+<p class="ECMAaddress">Web:  <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
+
+      <h2>Copyright Notice</h2>
+      <p>© 2018 Rick Waldron, Mid-World</p>
+
+      <h2>Software License</h2>
+      <p>All Software contained in this document ("Software") is protected by copyright and is being made available under the "BSD License", included below. This Software may be subject to third party rights (rights from parties other than Ecma International), including patent rights, and no licenses under such third party rights are granted under this license even if the third party concerned is a member of Ecma International. SEE THE ECMA CODE OF CONDUCT IN PATENT MATTERS AVAILABLE AT https://ecma-international.org/memento/codeofconduct.htm FOR INFORMATION REGARDING THE LICENSING OF PATENT CLAIMS THAT ARE REQUIRED TO IMPLEMENT ECMA INTERNATIONAL STANDARDS.</p>
+
+<p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
+
+<ol>
+  <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+  <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+  <li>Neither the name of the authors nor Ecma International may be used to endorse or promote products derived from this software without specific prior written permission.</li>
+</ol>
+
+<p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+
+    </emu-annex></div></body>

--- a/test/boilerplate-license.fixture
+++ b/test/boilerplate-license.fixture
@@ -1,0 +1,5 @@
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+<p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>

--- a/test/boilerplate-license.html
+++ b/test/boilerplate-license.html
@@ -1,0 +1,13 @@
+<pre class=metadata>
+title:     test title!
+toc:       false
+date:      2018-04-02
+assets:    none
+stage:     0
+status:    draft
+contributors: Rick Waldron, Mid-World
+copyright: true
+boilerplate:
+  license: test/boilerplate-license.fixture
+</pre>
+

--- a/test/boilerplate-license.html.baseline
+++ b/test/boilerplate-license.html.baseline
@@ -1,0 +1,31 @@
+<!doctype html>
+<head><meta charset="utf-8"><title>test title!</title></head><body><div id="spec-container"><h1 class="title first">test title!</h1>
+
+<emu-annex id="sec-copyright-and-software-license">
+      <h1><span class="secnum">A</span>Copyright &amp; Software License</h1>
+      <p class="ECMAaddress">Ecma International</p>
+<p class="ECMAaddress">Rue du Rhone 114</p>
+<p class="ECMAaddress">CH-1204 Geneva</p>
+<p class="ECMAaddress">Tel: +41 22 849 6000</p>
+<p class="ECMAaddress">Fax: +41 22 849 6001</p>
+<p class="ECMAaddress">Web:  <a href="https://ecma-international.org/">https://ecma-international.org/</a></p>
+
+      <h2>Copyright Notice</h2>
+      <p>© 2018 Ecma International</p>
+
+<p>This draft document may be copied and furnished to others, and derivative works that comment on or otherwise explain it or assist in its implementation may be prepared, copied, published, and distributed, in whole or in part, without restriction of any kind, provided that the above copyright notice and this section are included on all such copies and derivative works. However, this document itself may not be modified in any way, including by removing the copyright notice or references to Ecma International, except as needed for the purpose of developing any document or deliverable produced by Ecma International.</p>
+
+<p>This disclaimer is valid only prior to final version of this document. After approval all rights on the standard are reserved by Ecma International.</p>
+
+<p>The limited permissions are granted through the standardization phase and will not be revoked by Ecma International or its successors or assigns during this time.</p>
+
+<p>This document and the information contained herein is provided on an "AS IS" basis and ECMA INTERNATIONAL DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY OWNERSHIP RIGHTS OR ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.</p>
+
+      <h2>Software License</h2>
+      <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+<p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+
+    </emu-annex></div></body>


### PR DESCRIPTION
I want to write Johnny-Five related spec documents and I want to use ecmarkup, but right now I can't. This feature enables using ecmarkup for non-Ecma specifications; and while that may sound a little self-contradictory, ecmarkup is a great tool for writing and generating specification documents, and sometimes those specifications don't have a standards body (yet?) or will never become an Ecma spec (for whatever reason). Anyway, this is useful. 



![](https://i.gyazo.com/23b5b281d4c0ea3e3383a91fc7d7b77c.png)
![](https://i.gyazo.com/58360a3ffc51b571b68c03e0885a6d1d.png)
![](https://i.gyazo.com/55cffed4dfcb43035152d4822611606c.png)