### PR TITLE
Switch to Grammar.convert and sync code paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
     "@types/jsdom": {
       "version": "2.0.32",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-2.0.32.tgz",
-      "integrity": "sha1-5sqgJYk6TWgGv09m0PQUY08ButE=",
+      "integrity": "sha512-xaHlMIzlReyciMIWGJBnkEdHngCOEpik2ojt9tJFe7rD+QiObCIcmr9/tAqxn7l1jflQ3wEIkh7+gt4ls5n1Dw==",
       "dev": true,
       "requires": {
         "@types/jquery": "3.2.12",
@@ -916,9 +916,9 @@
       "dev": true
     },
     "grammarkdown": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-2.0.9.tgz",
-      "integrity": "sha512-qv4j+XXzptdG4o8AbuKok+hXUcl5pKVNk4WKuXWPINTwivkPcZbt7xa5qPjdzkD5vm4vFcrL2sX04lvy7AkUzg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-2.0.11.tgz",
+      "integrity": "sha512-udzyhGg36U0yLEv3p5VAMAIx9LKtx+uYwkopu30SU0C7/GQKXNp3TxW6GKiZ6DWlju8rqDSkBstnulaF1Ss+4g==",
       "requires": {
         "prex": "0.4.2"
       }
@@ -1759,7 +1759,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,9 +916,9 @@
       "dev": true
     },
     "grammarkdown": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-2.0.8.tgz",
-      "integrity": "sha512-Je3em8jIO0YlW52lwoCFKgRgk+18MS6Xnvhl7Y9dRO2LeB4800llepe+i05l5xXzn9+n/ox/fTXAudMfBaS6Mw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-2.0.9.tgz",
+      "integrity": "sha512-qv4j+XXzptdG4o8AbuKok+hXUcl5pKVNk4WKuXWPINTwivkPcZbt7xa5qPjdzkD5vm4vFcrL2sX04lvy7AkUzg==",
       "requires": {
         "prex": "0.4.2"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bluebird": "^3.4.5",
     "chalk": "^1.1.1",
     "ecmarkdown": "^3.0.9",
-    "grammarkdown": "^2.0.9",
+    "grammarkdown": "^2.0.11",
     "he": "^1.1.1",
     "highlight.js": "^9.0.0",
     "html-escape": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bluebird": "^3.4.5",
     "chalk": "^1.1.1",
     "ecmarkdown": "^3.0.9",
-    "grammarkdown": "^2.0.8",
+    "grammarkdown": "^2.0.9",
     "he": "^1.1.1",
     "highlight.js": "^9.0.0",
     "html-escape": "^1.0.2",

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -6,14 +6,14 @@ var __awaiter = require('./awaiter');
 
 /*@internal*/
 export default class Algorithm extends Builder {
-  static async enter(context: Context) {
+  static enter(context: Context) {
     const { node } = context;
     // Need to process emu-grammar elements first so emd doesn't trash the syntax inside emu-grammar nodes
     const grammarNodes = node.querySelectorAll('emu-grammar');
     for (let i = 0; i < grammarNodes.length; i++) {
       let gn = grammarNodes[i];
       context.node = gn as HTMLElement;
-      await Grammar.enter(context);
+      Grammar.enter(context);
       Grammar.exit(context);
       context.node = node;
     }

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -29,9 +29,9 @@ export default class Builder {
     utils.logWarning(str);
   }
 
-  static enter(context: Context): PromiseLike<void> | void {
+  static enter(context: Context): void {
     throw new Error('Builder not implemented');
   }
-  static exit(context: Context): PromiseLike<void> | void { } 
+  static exit(context: Context): void { } 
   static elements: string[] = [];
 }

--- a/src/Grammar.ts
+++ b/src/Grammar.ts
@@ -9,7 +9,7 @@ const globalEndTagRe = /<\/?(emu-\w+|h?\d|p|ul|table|pre|code)\b[^>]*>/ig;
 
 /*@internal*/
 export default class Grammar extends Builder {
-  static async enter({spec, node, inAlg}: Context) {
+  static enter({spec, node, inAlg}: Context) {
     // we process grammar nodes in algorithms separately (in Algorithm.ts)
     if (inAlg) return;
 
@@ -58,19 +58,12 @@ export default class Grammar extends Builder {
       }
     }
 
-    const host = new Host({
-      async readFile(_: string) { return content; },
-      async writeFile(_: string, output: string) { content = output; }
-    });
-
     const options: CompilerOptions = {
       format: EmitFormat.ecmarkup,
       noChecks: true
     };
 
-    const grammar = new GrammarFile(['file.grammar'], options, host);
-    await grammar.emit(/*sourceFile*/ undefined, /*writeFile*/ undefined, spec.cancellationToken); // updates content
-    node.innerHTML = content;
+    node.innerHTML = GrammarFile.convert(content, options, /*hostFallback*/ undefined, spec.cancellationToken);
   }
 
   static elements = ['EMU-GRAMMAR'];

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -207,7 +207,7 @@ export default class Spec {
     const document = this.doc;
     const walker = document.createTreeWalker(document.body, 1 | 4 /* elements and text nodes */);
 
-    await walk(walker, context);
+    walk(walker, context);
 
     this.autolink();
 
@@ -240,6 +240,7 @@ export default class Spec {
 
     await this.buildAssets();
 
+    this._log('Done.');
     return this;
   }
 
@@ -668,7 +669,7 @@ async function loadImports(spec: Spec, rootElement: HTMLElement, rootPath: strin
   }
 }
 
-async function walk (walker: TreeWalker, context: Context) {
+function walk (walker: TreeWalker, context: Context) {
   // When we set either of these states we need to know to unset when we leave the element.
   let changedInNoAutolink = false;
   let changedInNoEmd = false;
@@ -754,12 +755,12 @@ async function walk (walker: TreeWalker, context: Context) {
   }
 
   const visitor = visitorMap[context.node.nodeName];
-  if (visitor) await visitor.enter(context);
+  if (visitor) visitor.enter(context);
 
   const firstChild = walker.firstChild();
   if (firstChild) {
     while (true) {
-      await walk(walker, context);
+      walk(walker, context);
       const next = walker.nextSibling(); 
       if (!next) break;
     }
@@ -767,7 +768,7 @@ async function walk (walker: TreeWalker, context: Context) {
     context.node = walker.currentNode as HTMLElement;
   }
 
-  if (visitor) await visitor.exit(context);
+  if (visitor) visitor.exit(context);
   if (changedInNoAutolink) context.inNoAutolink = false;
   if (changedInNoEmd) context.inNoEmd = false;
   context.currentId = parentId;


### PR DESCRIPTION
- Upgrade grammarkdown to 2.0.11 (only interesting change was inclusion of `Grammar.convert` static method)
- Switch to calling `Grammar.convert` (performs synchronous parse and emit to a string)
- Switch `Grammar.enter`, `Algorithm.enter`, and `walk` back to sync execution.