### PR TITLE
Optimize performance

### DIFF
--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -186,6 +186,10 @@ export default class Spec {
     7. Add CSS & JS dependencies.
     */
     
+    // for better performance, make sure every node is visited before making any changes
+    this._log('Priming DOM...');
+    this.toHTML();
+
     this._log('Loading biblios...');
     await this.loadES6Biblio();
     await this.loadBiblios();

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -690,108 +690,101 @@ async function loadImports(spec: Spec, rootElement: HTMLElement, rootPath: strin
 }
 
 function walk (walker: TreeWalker, context: Context) {
-  const spec = context.spec;
-  const rootNode = walker.currentNode as HTMLElement;
-  const parentIds = [];
-  const visitors = [];
+  // When we set either of these states we need to know to unset when we leave the element.
+  let changedInNoAutolink = false;
+  let changedInNoEmd = false;
+  const { spec, node } = context;
 
-  // Track context elements for special state flags so we know when to unset them.
-  let restoreAutolink = null;
-  let restoreEmd = null;
+  context.node = walker.currentNode as HTMLElement;
+  context.tagStack.push(context.node);
 
-  visit: while (true) {
-    let node = context.node = walker.currentNode as HTMLElement;
-
-    if (node === context.startEmd) {
-      context.startEmd = null;
-      context.inNoEmd = false;
-    }
-
-    if (node.nodeType === 3) {
-      // walked to a text node
-
-      if (node.nodeValue!.trim() !== '') {
-        if (!context.inNoEmd) {
-          // new nodes as a result of emd processing should be skipped
-          context.inNoEmd = true;
-          context.startEmd = walker.nextNode();
-          if (context.startEmd) walker.previousNode();
-
-          utils.emdTextNode(spec, node);
-        }
-
-        if (!context.inNoAutolink) {
-          // stuff the text nodes into an array for auto-linking with later
-          // (since we can't autolink at this point without knowing the biblio).
-          const clause = context.clauseStack[context.clauseStack.length - 1] || spec;
-          const namespace = clause.namespace;
-          spec._textNodes[namespace] = spec._textNodes[namespace] || [];
-          spec._textNodes[namespace].push({
-            node: node,
-            clause: clause,
-            inAlg: context.inAlg,
-            currentId: context.currentId
-          });
-        }
-      }
-
-    } else if (node.nodeType === 1) {
-      // node is an HTMLElement (node type 1)
-
-      // entering
-      if (context.tagStack[context.tagStack.length - 1] !== node) {
-        context.tagStack.push(node);
-
-        // handle oldids
-        let oldids = node.getAttribute('oldids');
-        if (oldids) {
-          if (!node.children) {
-            throw new Error("oldids found on unsupported element: " + node.nodeName);
-          }
-          oldids.split(/,/g).map(s => s.trim()).forEach(oid => {
-            let s = spec.doc.createElement('span');
-            s.setAttribute('id', oid);
-            node.insertBefore(s, node.children[0]);
-          })
-        }
-
-        parentIds.push(context.currentId);
-        let contextId = node.getAttribute('id');
-        if (contextId !== null) context.currentId = contextId;
-
-        // See if we should stop auto-linking here.
-        if (!context.inNoAutolink && NO_CLAUSE_AUTOLINK.has(node.nodeName)) {
-          context.inNoAutolink = true;
-          restoreAutolink = node;
-        }
-
-        // check if entering a noEmd tag
-        if (!context.inNoEmd && NO_EMD.has(node.nodeName)) {
-          context.inNoEmd = true;
-          restoreEmd = node;
-        }
-
-        const visitor = visitorMap[node.nodeName];
-        visitors.push(visitor);
-        if (visitor) visitor.enter(context);
-
-        if (walker.firstChild()) continue;
-      }
-
-      // exiting
-      const visitor = visitors.pop();
-      if (visitor) visitor.exit(context);
-      if (node === restoreAutolink) context.inNoAutolink = false;
-      if (node === restoreEmd) context.inNoEmd = false;
-      context.currentId = parentIds.pop() as string | null;
-      context.tagStack.pop();
-      if (node === rootNode) break;
-    }
-
-    if (!walker.nextSibling()) {
-      walker.parentNode();
-    }
+  if (context.node === context.startEmd) {
+    context.startEmd = null;
+    context.inNoEmd = false;
   }
+
+
+  if (context.node.nodeType === 3) {
+    // walked to a text node
+
+    if (context.node.nodeValue!.trim().length === 0) return; // skip empty nodes; nothing to do!
+    if (!context.inNoEmd) {
+      // new nodes as a result of emd processing should be skipped
+      context.inNoEmd = true;
+      context.startEmd = walker.nextNode();
+      if (context.startEmd) walker.previousNode();
+
+      utils.emdTextNode(context.spec, context.node);
+    }
+
+    if (!context.inNoAutolink) {
+      // stuff the text nodes into an array for auto-linking with later
+      // (since we can't autolink at this point without knowing the biblio).
+      const clause = context.clauseStack[context.clauseStack.length - 1] || context.spec;
+      const namespace = clause.namespace;
+      context.spec._textNodes[namespace] = context.spec._textNodes[namespace] || [];
+      context.spec._textNodes[namespace].push({
+        node: context.node,
+        clause: clause,
+        inAlg: context.inAlg,
+        currentId: context.currentId
+      });
+      
+    }
+    return;
+  }
+
+  // context.node is an HTMLElement (node type 1)
+  
+  // handle oldids
+  let oldids = context.node.getAttribute('oldids');
+  if (oldids) {
+    if (!context.node.children) {
+      throw new Error("oldids found on unsupported element: " + context.node.nodeName);
+    }
+    oldids.split(/,/g).map(s => s.trim()).forEach(oid => {
+      let s = spec.doc.createElement('span');
+      s.setAttribute('id', oid);
+      context.node.insertBefore(s, context.node.children[0]);
+    })
+  }
+
+  let parentId = context.currentId;
+  let contextId = context.node.getAttribute('id');
+  if (contextId !== null) {
+    context.currentId = contextId;
+  }
+
+  // See if we should stop auto-linking here.
+  if (!context.inNoAutolink && NO_CLAUSE_AUTOLINK.has(context.node.nodeName)) {
+    context.inNoAutolink = true;
+    changedInNoAutolink = true;
+  }
+
+  // check if entering a noEmd tag
+  if (!context.inNoEmd && NO_EMD.has(context.node.nodeName)) {
+    context.inNoEmd = true;
+    changedInNoEmd = true;
+  }
+
+  const visitor = visitorMap[context.node.nodeName];
+  if (visitor) visitor.enter(context);
+
+  if (walker.firstChild()) {
+    while (true) {
+      walk(walker, context);
+      const next = walker.nextSibling(); 
+      if (!next) break;
+    }
+    walker.parentNode();
+    context.node = walker.currentNode as HTMLElement;
+  }
+
+  if (visitor) visitor.exit(context);
+  if (changedInNoAutolink) context.inNoAutolink = false;
+  if (changedInNoEmd) context.inNoEmd = false;
+  context.currentId = parentId;
+  context.tagStack.pop();
 }
 
 const jsDependencies = ['menu.js', 'findLocalReferences.js'];

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -711,16 +711,8 @@ function walk (walker: TreeWalker, context: Context) {
     if (!context.inNoEmd) {
       // new nodes as a result of emd processing should be skipped
       context.inNoEmd = true;
-      // inNoEmd is set to true when we walk to this node 
-      let node = context.node as Node | null;
-      while(node && !node.nextSibling) {
-        node = node.parentNode;
-      }
-
-      if (node) {
-        context.startEmd = node.nextSibling;
-      }
-      // else, inNoEmd will just continue to the end of the file
+      context.startEmd = walker.nextNode();
+      if (context.startEmd) walker.previousNode();
 
       utils.emdTextNode(context.spec, context.node);
     }
@@ -729,7 +721,7 @@ function walk (walker: TreeWalker, context: Context) {
       // stuff the text nodes into an array for auto-linking with later
       // (since we can't autolink at this point without knowing the biblio).
       const clause = context.clauseStack[context.clauseStack.length - 1] || context.spec;
-      const namespace = clause ? clause.namespace : context.spec.namespace;
+      const namespace = clause.namespace;
       context.spec._textNodes[namespace] = context.spec._textNodes[namespace] || [];
       context.spec._textNodes[namespace].push({
         node: context.node,
@@ -777,8 +769,7 @@ function walk (walker: TreeWalker, context: Context) {
   const visitor = visitorMap[context.node.nodeName];
   if (visitor) visitor.enter(context);
 
-  const firstChild = walker.firstChild();
-  if (firstChild) {
+  if (walker.firstChild()) {
     while (true) {
       walk(walker, context);
       const next = walker.nextSibling(); 

--- a/src/Spec.ts
+++ b/src/Spec.ts
@@ -707,7 +707,7 @@ function walk (walker: TreeWalker, context: Context) {
   if (context.node.nodeType === 3) {
     // walked to a text node
 
-    if (context.node.textContent!.trim().length === 0) return; // skip empty nodes; nothing to do!
+    if (context.node.nodeValue!.trim().length === 0) return; // skip empty nodes; nothing to do!
     if (!context.inNoEmd) {
       // new nodes as a result of emd processing should be skipped
       context.inNoEmd = true;
@@ -750,18 +750,19 @@ function walk (walker: TreeWalker, context: Context) {
   }
 
   let parentId = context.currentId;
-  if (context.node.hasAttribute('id')) {
-    context.currentId = context.node.getAttribute('id');
+  let contextId = context.node.getAttribute('id');
+  if (contextId !== null) {
+    context.currentId = contextId;
   }
 
   // See if we should stop auto-linking here.
-  if (NO_CLAUSE_AUTOLINK.has(context.node.nodeName) && !context.inNoAutolink) {
+  if (!context.inNoAutolink && NO_CLAUSE_AUTOLINK.has(context.node.nodeName)) {
     context.inNoAutolink = true;
     changedInNoAutolink = true;
   }
 
   // check if entering a noEmd tag
-  if (NO_EMD.has(context.node.nodeName) && !context.inNoEmd) {
+  if (!context.inNoEmd && NO_EMD.has(context.node.nodeName)) {
     context.inNoEmd = true;
     changedInNoEmd = true;
   }

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -22,10 +22,10 @@ export const NO_CLAUSE_AUTOLINK = new Set([
 
 const COMMON_ABSTRACT_OP = new Set(['Call', 'Set', 'Type', 'UTC', 'min', 'max']);
 const COMMON_TERM = new Set(['List', 'Reference', 'Record']);
+const autolinkTemplateCache = new WeakMap();
 
 export function autolink(node: Node, replacer: RegExp, autolinkmap: AutoLinkMap, clause: Clause | Spec, currentId: string | null, allowSameId: boolean) {
   const spec = clause.spec;
-  const template = spec.doc.createElement('template');
   const content = escape(node.textContent!);
   const autolinked = content.replace(replacer, match => {
     const entry = autolinkmap[narrowSpace(match.toLowerCase())];
@@ -48,6 +48,11 @@ export function autolink(node: Node, replacer: RegExp, autolinkmap: AutoLinkMap,
   });
 
   if (autolinked !== content) {
+    let template = autolinkTemplateCache.get(spec);
+    if ( !template ) {
+      template = spec.doc.createElement('template');
+      autolinkTemplateCache.set(spec, template);
+    }
     template.innerHTML = autolinked;
     const newXrefNodes = utils.replaceTextNode(node, template.content);
     const newXrefs = newXrefNodes.map(node =>

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -20,6 +20,9 @@ export const NO_CLAUSE_AUTOLINK = new Set([
   'DFN'
 ]);
 
+const COMMON_ABSTRACT_OP = new Set(['Call', 'Set', 'Type', 'UTC', 'min', 'max']);
+const COMMON_TERM = new Set(['List', 'Reference', 'Record']);
+
 export function autolink(node: Node, replacer: RegExp, autolinkmap: AutoLinkMap, clause: Clause | Spec, currentId: string | null, allowSameId: boolean) {
   const spec = clause.spec;
   const template = spec.doc.createElement('template');
@@ -71,7 +74,7 @@ export function replacerForNamespace(namespace: string, biblio: Biblio) : [RegEx
       const key = regexpEscape(entry.key!);
 
       if (entry.type === 'term') {
-        if (isCommonTerm(key)) {
+        if (COMMON_TERM.has(key)) {
           return '\\b' +
                   widenSpace(key) +
                   '\\b(?!\\.\\w|%%|\\]\\])';
@@ -84,7 +87,7 @@ export function replacerForNamespace(namespace: string, biblio: Biblio) : [RegEx
         }
       } else {
         // type is "op"
-        if (isCommonAbstractOp(key)) {
+        if (COMMON_ABSTRACT_OP.has(key)) {
           return '\\b' + key + '\\b(?=\\()';
         } else {
           return '\\b' + key + '\\b(?!\\.\\w|%%|\\]\\])';
@@ -98,14 +101,6 @@ export function replacerForNamespace(namespace: string, biblio: Biblio) : [RegEx
 
 export interface AutoLinkMap {
   [key: string]: BiblioEntry;
-}
-
-function isCommonAbstractOp(op: string) {
-  return op === 'Call' || op === 'Set' || op === 'Type' || op === 'UTC' || op === 'min' || op === 'max';
-}
-
-function isCommonTerm(op: string) {
-  return op === 'List' || op === 'Reference' || op === 'Record';
 }
 
 // regexp-string where the first character is case insensitive

--- a/src/autolinker.ts
+++ b/src/autolinker.ts
@@ -22,7 +22,6 @@ export const NO_CLAUSE_AUTOLINK = new Set([
 
 const COMMON_ABSTRACT_OP = new Set(['Call', 'Set', 'Type', 'UTC', 'min', 'max']);
 const COMMON_TERM = new Set(['List', 'Reference', 'Record']);
-const autolinkTemplateCache = new WeakMap();
 
 export function autolink(node: Node, replacer: RegExp, autolinkmap: AutoLinkMap, clause: Clause | Spec, currentId: string | null, allowSameId: boolean) {
   const spec = clause.spec;
@@ -48,13 +47,7 @@ export function autolink(node: Node, replacer: RegExp, autolinkmap: AutoLinkMap,
   });
 
   if (autolinked !== content) {
-    let template = autolinkTemplateCache.get(spec);
-    if ( !template ) {
-      template = spec.doc.createElement('template');
-      autolinkTemplateCache.set(spec, template);
-    }
-    template.innerHTML = autolinked;
-    const newXrefNodes = utils.replaceTextNode(node, template.content);
+    const newXrefNodes = utils.replaceTextNode(node, autolinked);
     const newXrefs = newXrefNodes.map(node =>
       new Xref(spec, node as HTMLElement, clause as Clause, clause.namespace, node.getAttribute('href')!, node.getAttribute('aoid')!)
     )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,8 +49,8 @@ export function replaceTextNode(node: Node, content: string) {
   // Parse the content
   let template = templateCache.get(node.ownerDocument);
   if ( !template ) {
-	template = node.ownerDocument.createElement('template');
-	templateCache.set(node.ownerDocument, template);
+    template = node.ownerDocument.createElement('template');
+    templateCache.set(node.ownerDocument, template);
   }
   template.innerHTML = content;
   const frag = template.content as DocumentFragment;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,12 +7,19 @@ import emd = require('ecmarkdown');
 import fs = require('fs');
 
 /*@internal*/
+const emdTextNodeTemplateCache = new WeakMap();
+
+/*@internal*/
 export function emdTextNode(spec: Spec, node: Node) {
   // emd strips starting and ending spaces which we want to preserve
   const startSpace = node.textContent!.match(/^\s*/)![0];
   const endSpace = node.textContent!.match(/\s*$/)![0];
 
-  const template = spec.doc.createElement('template');
+  let template = emdTextNodeTemplateCache.get(spec);
+  if ( !template ) {
+    template = spec.doc.createElement('template');
+    emdTextNodeTemplateCache.set(spec, template);
+  }
   template.innerHTML = startSpace + emd.fragment(node.textContent!) + endSpace;
 
   replaceTextNode(node, template.content);


### PR DESCRIPTION
![meme](https://i.imgflip.com/2dosho.jpg)
How about an 80% speedup? ~~Profiling suggests that further improvements may be possible by updating the `walk` function in src/Spec.ts to traverse the DOM directly rather than call itself recursively, but I have left that out of this PR.~~

## Before
```sh
~/…/ecma262$ npm run clean && /usr/bin/time -p npm run build-master

> ecma262@1.0.0 clean /home/rgibson/Projects/ecma262
> rm -rf out


> ecma262@1.0.0 build-master /home/rgibson/Projects/ecma262
> mkdir out && cp -R img out && ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js

[2018-07-09T19:04:34.924Z] Loading biblios...
[2018-07-09T19:04:34.962Z] Loading imports...
[2018-07-09T19:04:35.238Z] Building boilerplate...
[2018-07-09T19:04:35.488Z] Walking document, building various elements...
[2018-07-09T19:04:51.989Z] Autolinking terms and abstract ops...
[2018-07-09T19:05:00.203Z] Linking xrefs...
[2018-07-09T19:05:01.895Z] Linking non-terminal references...
[2018-07-09T19:05:03.811Z] Linking production references...
[2018-07-09T19:05:16.311Z] Building reference graph...
[2018-07-09T19:05:17.008Z] Highlighting syntax...
[2018-07-09T19:05:19.037Z] Building table of contents...
[2018-07-09T19:05:21.230Z] Writing js file to out/ecmarkup.js...
[2018-07-09T19:05:21.232Z] Writing css file to out/ecmarkup.css...
[2018-07-09T19:05:21.285Z] Found existing js link to ecmarkup.js, skipping inlining...
[2018-07-09T19:05:21.378Z] Found existing css link to ecmarkup.css, skipping inlining...
[2018-07-09T19:05:21.378Z] Done.
[2018-07-09T19:05:21.378Z] Writing output to out/index.html
real 182.14
user 182.65
sys 0.42
```

## After
```sh
~/…/ecma262$ npm run clean && /usr/bin/time -p npm run build-master

> ecma262@1.0.0 clean /home/rgibson/Projects/ecma262
> rm -rf out


> ecma262@1.0.0 build-master /home/rgibson/Projects/ecma262
> mkdir out && cp -R img out && ecmarkup --verbose spec.html out/index.html --css out/ecmarkup.css --js out/ecmarkup.js

[2018-07-09T19:10:07.023Z] Priming DOM...
[2018-07-09T19:10:07.565Z] Loading biblios...
[2018-07-09T19:10:07.593Z] Loading imports...
[2018-07-09T19:10:07.882Z] Building boilerplate...
[2018-07-09T19:10:08.134Z] Walking document, building various elements...
[2018-07-09T19:10:19.675Z] Autolinking terms and abstract ops...
[2018-07-09T19:10:22.932Z] Linking xrefs...
[2018-07-09T19:10:24.413Z] Linking non-terminal references...
[2018-07-09T19:10:26.045Z] Linking production references...
[2018-07-09T19:10:26.388Z] Building reference graph...
[2018-07-09T19:10:27.055Z] Highlighting syntax...
[2018-07-09T19:10:28.875Z] Building table of contents...
[2018-07-09T19:10:30.780Z] Writing js file to out/ecmarkup.js...
[2018-07-09T19:10:30.782Z] Writing css file to out/ecmarkup.css...
[2018-07-09T19:10:30.876Z] Found existing js link to ecmarkup.js, skipping inlining...
[2018-07-09T19:10:30.923Z] Found existing css link to ecmarkup.css, skipping inlining...
[2018-07-09T19:10:30.923Z] Done.
[2018-07-09T19:10:30.923Z] Writing output to out/index.html
real 29.44
user 29.90
sys 0.33
```