### PR TITLE
Insert a selectable space between heading number and text

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -297,7 +297,7 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 .secnum {
   text-decoration: none;
-  margin-right: 10px;
+  margin-right: 5px;
 }
 
 h1 span.title {

--- a/src/Clause.ts
+++ b/src/Clause.ts
@@ -63,6 +63,7 @@ export default class Clause extends Builder {
     const numElem = this.spec.doc.createElement('span');
     numElem.setAttribute('class', 'secnum');
     numElem.textContent = this.number;
+    this.header.insertBefore(this.spec.doc.createTextNode(' '), this.header.firstChild);
     this.header.insertBefore(numElem, this.header.firstChild);
   }
 


### PR DESCRIPTION
I'm sick of selecting text like "20.3.1.1Time Values and Time Range".