### PR TITLE
Remove the rule that suppresses the display of emu-mods

### DIFF
--- a/css/elements.css
+++ b/css/elements.css
@@ -248,10 +248,6 @@ emu-mods {
     font-weight: normal;
 }
 
-emu-production[collapsed] emu-mods {
-  display: none;
-}
-
 emu-params, emu-opt {
   margin-right: 1ex;
   font-family: monospace;


### PR DESCRIPTION
In practice, an `<emu-mods>` contains an `<emu-params>` and/or an `<emu-opt>`. My guess is that this rule was introduced with only `<emu-params>` in mind, as there are situations in which you might reasonably want to suppress the display of `<emu-params>`, but you should never suppress an `<emu-opt>`.

---

An alternative to removing the rule (and, if my above guess is correct, a solution that would be more in line with the original intent) would be to change its selector from:
  `emu-production[collapsed] emu-mods`
to:
  `emu-production[collapsed] emu-params`
I.e., in a collapsed production, suppress the display of *only* the grammatical parameters (GPs).

However, I didn't propose that solution because it's incomplete in 3 ways:

- It doesn't suppress GPs in all contexts where we want to suppress them. (Generally we want to suppress GPs in any non-defining production, which includes all the collapsed production, but also includes lots of non-collapsed productions.)

- It doesn't suppress all the annotations we typically want to suppress (e.g. lookahead restrictions and no-LineTerminator-here annotations) because those don't occur in `<emu-mods>`.

- It doesn't allow for the rare cases where we *don't* want to suppress GPs (and annotations).

Instead (in ecma262 at least), we explicitly remove unnecessary GPs and annotations from all productions where we don't want them to appear. (Note that this also has the benefit of making the source easier to read.) So even with the suggested modification, the rule would be basically pointless.

Better to just delete it.

---

This PR:
- resolves #108
- resolves #122
- resolves tc39/ecma262#536
- resolves tc39/ecma262#908
- resolves tc39/ecma262#1139
- resolves tc39/ecma262#1663